### PR TITLE
Fix #31: Calling sendTextMessage after sending MMS causes message to …

### DIFF
--- a/lib/MessageApiClient.ts
+++ b/lib/MessageApiClient.ts
@@ -51,10 +51,12 @@ export class MessageApiClient {
      * For Twitter: use the Twitter Snowflake ID of the account you want to use as sender.
      * @param message the body of the SMS message to be sent
      * @param reference (optional) reference to the message to query it later in the CM.platform.
-     */public sendTextMessage(to: string[], from: string, message: string, reference: string = undefined) {
+     */
+    public sendTextMessage(to: string[], from: string, message: string, reference: string = undefined) {
         return this
             .createMessage()
             .setMessage(to, from, message, reference)
+            .setAllowedChannels(['SMS'])
             .send();
     }
 }


### PR DESCRIPTION
…be incorrectly sent as MMS

This is a breaking change because it changes the behavior of `sendTextMessage(...)` in some cases (such as when the previous message was sent as an MMS). `sendTextMessage(...)` should always send as an SMS according to the comment above the function.